### PR TITLE
Add Canal+ online to the sources type

### DIFF
--- a/src/app/services/source-manager/types.ts
+++ b/src/app/services/source-manager/types.ts
@@ -85,6 +85,23 @@ export const DEFAULT_SOURCES: Map<string, Source> = new Map([
     }
   ],
   [
+    'canalplus',
+    {
+      name: 'Canal+ online',
+      category: CategoryType.Streaming,
+      url: 'https://canalplus.com/',
+      colors: {
+        dark: "#000000",
+        light: "#000000"
+      },
+      logos: {
+        dark: "https://i.imgur.com/Zj8cNLw.png",
+        light: "https://i.imgur.com/Zj8cNLw.png"
+      },
+      visible: true
+    }
+  ],
+  [
     'hulu',
     {
       name: 'Hulu',


### PR DESCRIPTION
CANAL+ online is one of the IPTV providers in serveral countries. Adding this as a source type could help serveral viewers. 
